### PR TITLE
Ensure compatibility with weird debian which.

### DIFF
--- a/bin/bumper
+++ b/bin/bumper
@@ -21,7 +21,7 @@ file_was_modified() {
 }
 
 available_in_path() {
-    which -s ${1}
+    which ${1} > /dev/null
 }
 
 upcase() {


### PR DESCRIPTION
- debianutils has a strange version of which that doesn't have a -s
  argument so we just pipe to /dev/null instead.
